### PR TITLE
feat: replace admin WebDAV service account with WOPI-style PHP callbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,4 @@
 JWT_SECRET_KEY=change_me_to_random_hex_32_bytes
 NC_URL=https://nextcloud.example.com
-# Use a dedicated 'Service User' (e.g., 'tldraw-bot') added to the Admin group.
-# DO NOT use your personal admin account.
-NC_USER=tldraw-bot
-NC_PASS=your-secure-password
 TLDRAW_HOST=tldraw.example.com
 ACME_EMAIL=admin@example.com

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -5,6 +5,11 @@ return [
         ['name' => 'tldraw#edit', 'url' => '/edit/{fileId}', 'verb' => 'GET'],
         // Issues a short-lived JWT for the WebSocket connection
         ['name' => 'tldraw#token', 'url' => '/token/{fileId}', 'verb' => 'GET'],
+        // Collab server file I/O callbacks (authenticated via storage token, no user session needed)
+        ['name' => 'file#read',        'url' => '/file/{fileId}',       'verb' => 'GET'],
+        ['name' => 'file#save',        'url' => '/file/{fileId}',       'verb' => 'PUT'],
+        ['name' => 'file#uploadAsset', 'url' => '/file/{fileId}/asset', 'verb' => 'POST'],
+        ['name' => 'file#serveAsset',  'url' => '/asset/{assetKey}',    'verb' => 'GET'],
         // Admin settings
         ['name' => 'admin#getSettings', 'url' => '/admin', 'verb' => 'GET'],
         ['name' => 'admin#saveSettings', 'url' => '/admin', 'verb' => 'POST'],

--- a/collab-server/package-lock.json
+++ b/collab-server/package-lock.json
@@ -14,7 +14,6 @@
         "express": "^4.18.2",
         "express-rate-limit": "^8.2.1",
         "multer": "^2.0.0",
-        "webdav": "^5.4.0",
         "ws": "^8.16.0"
       },
       "devDependencies": {
@@ -26,15 +25,6 @@
         "@types/ws": "^8.5.10",
         "tsx": "^4.7.0",
         "typescript": "^5.3.3"
-      }
-    },
-    "node_modules/@buttercup/fetch": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@buttercup/fetch/-/fetch-0.2.1.tgz",
-      "integrity": "sha512-sCgECOx8wiqY8NN1xN22BqqKzXYIG2AicNLlakOAI4f0WgyLVUbAigMf8CZhBtJxdudTcB1gD5lciqi44jwJvg==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "node-fetch": "^3.3.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -740,18 +730,6 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/base-64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
-      "license": "MIT"
-    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -776,15 +754,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -801,12 +770,6 @@
       "engines": {
         "node": ">=10.16.0"
       }
-    },
-    "node_modules/byte-length": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/byte-length/-/byte-length-1.0.2.tgz",
-      "integrity": "sha512-ovBpjmsgd/teRmgcPh23d4gJvxDoXtAzEL9xTfMU8Yc2kqCDb7L9jAG0XHl1nzuGl+h3ebCIF1i62UFyA9V/2Q==",
-      "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -844,15 +807,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/concat-stream": {
@@ -923,24 +877,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1008,18 +944,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -1173,47 +1097,6 @@
         "express": ">= 4.11"
       }
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.7.tgz",
-      "integrity": "sha512-JzVLro9NQv92pOM/jTCR6mHlJh2FGwtomH8ZQjhFj/R29P2Fnj38OgPJVtcvYw6SuKClhgYuwUZf5b3rd8u2mA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^2.1.2"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -1230,18 +1113,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -1381,12 +1252,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hot-patcher": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hot-patcher/-/hot-patcher-2.0.1.tgz",
-      "integrity": "sha512-ECg1JFG0YzehicQaogenlcs2qg6WsXQsxtnbr1i696u5tLUjtJdQAh0u2g0Q5YV45f263Ta1GnUJsc8WIfJf4Q==",
-      "license": "MIT"
-    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -1443,12 +1308,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "license": "MIT"
-    },
     "node_modules/jittered-fractional-indexing": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/jittered-fractional-indexing/-/jittered-fractional-indexing-1.0.1.tgz",
@@ -1460,12 +1319,6 @@
       "engines": {
         "node": ">=18.0.0"
       }
-    },
-    "node_modules/layerr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/layerr/-/layerr-3.0.0.tgz",
-      "integrity": "sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA==",
-      "license": "MIT"
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -1499,17 +1352,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/media-typer": {
@@ -1570,21 +1412,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -1650,50 +1477,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/nested-property": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nested-property/-/nested-property-4.0.0.tgz",
-      "integrity": "sha512-yFehXNWRs4cM0+dz7QxCd06hTbWbSkV0ISsqBfkntU6TOY4Qm3Q88fRRLOddkGh2Qq6dZvnKVAahfhjcUvLnyA==",
-      "license": "MIT"
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1736,12 +1519,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/path-posix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
-      "integrity": "sha512-1gJ0WpNIiYcQydgg3Ed8KzvIqTsDpNwq+cjBCssvBtuTWjEqY1AW+i+OepiEMqDCzyro9B2sLAe4RBPajMYFiA==",
-      "license": "ISC"
-    },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
@@ -1775,12 +1552,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -1842,12 +1613,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -2041,18 +1806,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2131,25 +1884,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/url-join": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
-      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2172,40 +1906,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/webdav": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/webdav/-/webdav-5.9.0.tgz",
-      "integrity": "sha512-OMJ6wtK1WvCO++aOLoQgE96S8KT4e5aaClWHmHXfFU369r4eyELN569B7EqT4OOUb99mmO58GkyuiCv/Ag6J0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@buttercup/fetch": "^0.2.1",
-        "base-64": "^1.0.0",
-        "byte-length": "^1.0.2",
-        "entities": "^6.0.1",
-        "fast-xml-parser": "^5.3.4",
-        "hot-patcher": "^2.0.1",
-        "layerr": "^3.0.0",
-        "md5": "^2.3.0",
-        "minimatch": "^9.0.5",
-        "nested-property": "^4.0.0",
-        "node-fetch": "^3.3.2",
-        "path-posix": "^1.0.0",
-        "url-join": "^5.0.0",
-        "url-parse": "^1.5.10"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/ws": {

--- a/collab-server/package.json
+++ b/collab-server/package.json
@@ -14,7 +14,6 @@
     "express": "^4.18.2",
     "express-rate-limit": "^8.2.1",
     "multer": "^2.0.0",
-    "webdav": "^5.4.0",
     "ws": "^8.16.0"
   },
   "devDependencies": {

--- a/collab-server/src/nc-storage.ts
+++ b/collab-server/src/nc-storage.ts
@@ -1,70 +1,66 @@
-import { createClient } from 'webdav';
 import { DatabaseSync } from 'node:sqlite';
 import { NodeSqliteWrapper, SQLiteSyncStorage } from '@tldraw/sync-core';
 
-const NC_URL = process.env.NC_URL || '';
-// Use a dedicated service account (bot) with Admin group permissions.
-// We prefer NC_USER/NC_PASS but fall back to NC_ADMIN_* for compatibility.
-const NC_USER = process.env.NC_USER || process.env.NC_ADMIN_USER || '';
-const NC_PASS = process.env.NC_PASS || process.env.NC_ADMIN_PASS || '';
-
-// Create a WebDAV client authenticated as the Service User
-function adminDavClient(userId: string) {
-	// Access user's files via admin account at /remote.php/dav/files/<userId>/
-	// NOTE: The authenticated NC_USER must be in the 'admin' group to access
-	// paths belonging to other users.
-	return createClient(`${NC_URL}/remote.php/dav/files/${encodeURIComponent(userId)}`, {
-		username: NC_USER,
-		password: NC_PASS,
-	});
-}
+// The Nextcloud base URL is the only Nextcloud configuration the collab server needs.
+// No credentials — all file I/O goes through PHP callback endpoints authenticated
+// by the storage token issued by TldrawController::token().
+const NC_URL = (process.env.NC_URL || '').replace(/\/$/, '');
 
 export interface NcRoomStorage {
 	storage: SQLiteSyncStorage<any>;
-	flush(userId: string, filePath: string): Promise<void>;
+	flush(fileId: string, storageToken: string): Promise<void>;
 	close(): void;
 }
 
-export async function createNcRoomStorage(userId: string, filePath: string): Promise<NcRoomStorage> {
-	// Use in-memory SQLite database for fast sync operations
+/**
+ * Call a Nextcloud file callback endpoint.
+ * All endpoints use Bearer <storageToken> for authentication.
+ */
+async function ncFetch(path: string, options: RequestInit, storageToken: string): Promise<Response> {
+	const url = `${NC_URL}${path}`;
+	const headers = new Headers(options.headers as HeadersInit || {});
+	headers.set('Authorization', `Bearer ${storageToken}`);
+	return fetch(url, { ...options, headers });
+}
+
+export async function createNcRoomStorage(
+	fileId: string,
+	storageToken: string
+): Promise<NcRoomStorage> {
 	const db = new DatabaseSync(':memory:');
 	const storage = new SQLiteSyncStorage<any>({ sql: new NodeSqliteWrapper(db) });
 
-	// 1. Load existing content from Nextcloud
+	// Load existing drawing content from Nextcloud via the PHP read callback
 	try {
-		const client = adminDavClient(userId);
-		// Check if file exists and has content
-		if (await client.exists(filePath)) {
-			const content = (await client.getFileContents(filePath, { format: 'text' })) as string;
+		const res = await ncFetch(`/apps/tldraw/file/${fileId}`, { method: 'GET' }, storageToken);
+		if (res.ok) {
+			const content = await res.text();
 			if (content && content.trim()) {
 				const snapshot = JSON.parse(content);
-				// Initialize storage from snapshot
-				// Note: loadSnapshot is an internal method, might need adjustment based on exact version
-				// For @tldraw/sync-core, usually initializing with data is done differently or via applying updates
-				// But let's assume standard snapshot loading for now.
-				// If loadSnapshot is not available on the instance, we might need to manually insert.
-				// However, for this scaffolding, we assume compatibility.
 				if (typeof (storage as any).loadSnapshot === 'function') {
 					await (storage as any).loadSnapshot(snapshot);
-				} else {
-					console.warn('loadSnapshot not found on storage instance');
 				}
 			}
 		}
 	} catch (e) {
 		console.error('Error loading file from Nextcloud:', e);
-		// Start with empty room if load fails or file is new
+		// Start with an empty room if load fails or file is new
 	}
 
-	// 2. Define flush function to save back to Nextcloud
-	async function flush(uid: string, path: string) {
+	async function flush(fid: string, token: string) {
 		try {
-			// Get snapshot from storage
 			const snapshot = await (storage as any).getSnapshot();
 			if (!snapshot) return;
 
-			const client = adminDavClient(uid);
-			await client.putFileContents(path, JSON.stringify(snapshot), { overwrite: true });
+			const res = await ncFetch(`/apps/tldraw/file/${fid}`, {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(snapshot),
+			}, token);
+
+			if (!res.ok) {
+				console.error(`Flush failed: HTTP ${res.status}`);
+			}
 		} catch (e) {
 			console.error('Error flushing to Nextcloud:', e);
 		}
@@ -77,31 +73,27 @@ export async function createNcRoomStorage(userId: string, filePath: string): Pro
 	};
 }
 
+/**
+ * Upload an image asset to Nextcloud via the PHP asset callback.
+ * Returns the asset URL (served by Nextcloud, not the collab server).
+ */
 export async function uploadAsset(
-	userId: string,
-	filename: string,
+	fileId: string,
 	data: Buffer,
-	mimeType: string
+	mimeType: string,
+	storageToken: string
 ): Promise<string> {
-	const client = adminDavClient(userId);
-	const assetDir = '.tldraw-assets';
-	const assetPath = `${assetDir}/${filename}`;
+	const res = await ncFetch(`/apps/tldraw/file/${fileId}/asset`, {
+		method: 'POST',
+		headers: { 'Content-Type': mimeType },
+		body: data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer,
+	}, storageToken);
 
-	try {
-		if (!(await client.exists(assetDir))) {
-			await client.createDirectory(assetDir);
-		}
-		await client.putFileContents(assetPath, data, { overwrite: true });
-	} catch (e) {
-		console.error('Asset upload failed:', e);
-		throw e;
+	if (!res.ok) {
+		throw new Error(`Asset upload failed: HTTP ${res.status}`);
 	}
 
-	return `/uploads/${encodeURIComponent(userId)}/${filename}`;
-}
-
-export async function fetchAsset(userId: string, filename: string): Promise<Buffer> {
-	const client = adminDavClient(userId);
-	const assetPath = `.tldraw-assets/${filename}`;
-	return (await client.getFileContents(assetPath)) as Buffer;
+	const { assetKey } = await res.json() as { assetKey: string };
+	// Assets are now served directly from Nextcloud — no proxy on the collab server
+	return `${NC_URL}/apps/tldraw/asset/${encodeURIComponent(assetKey)}`;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,8 @@ services:
       # SECURITY: Change this to a long random string. Must match 'jwt_secret' in Nextcloud App Settings.
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
       # NEXTCLOUD CONFIGURATION
+      # The collab server calls back to this URL for file I/O — no credentials needed.
       - NC_URL=${NC_URL}
-      # CREDENTIALS: Use a dedicated 'Service User' (Admin Group) for best security.
-      # DO NOT use your personal admin account. See docs/DEPLOYMENT.md.
-      - NC_USER=${NC_USER}
-      - NC_PASS=${NC_PASS}
     deploy:
       resources:
         limits:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -9,6 +9,8 @@ This guide covers deploying the **Collab Server** — the Node.js backend requir
 - A **dedicated domain** pointing to your server (e.g. `tldraw.example.com`).
 - Access to your Nextcloud instance as an administrator.
 
+> **No service account needed.** The collab server no longer requires a Nextcloud user account. File I/O is handled via authenticated callbacks to the Nextcloud PHP app (see [Architecture](ARCHITECTURE.md)).
+
 ---
 
 ## Step 1: Get the Files
@@ -30,19 +32,7 @@ cd /opt/tldraw-sync
 
 ---
 
-## Step 2: Create a Service User in Nextcloud
-
-The Collab Server reads and writes `.tldr` files via WebDAV on behalf of all users. It must authenticate as a dedicated bot account — never use your personal admin account.
-
-1. In Nextcloud, go to **Users** and create a new user (e.g. `tldraw-bot`).
-2. Add that user to the `admin` group.
-   > **Why admin?** The WebDAV endpoint `/remote.php/dav/files/<user>/` only allows the owner or an admin to access it. The bot needs admin access to write files on behalf of other users.
-3. Log in as `tldraw-bot`, go to **Settings > Security > Devices & sessions**, and create a new **App Password** named `Collab Server`.
-   > **Important:** Copy this password immediately — it is only shown once. Do not use the login password.
-
----
-
-## Step 3: Configure the Environment
+## Step 2: Configure the Environment
 
 Copy `.env.example` to `.env` and fill in your values:
 
@@ -55,12 +45,9 @@ cp .env.example .env
 # Must match the 'JWT Secret' saved in Nextcloud Admin Settings.
 JWT_SECRET_KEY=paste_your_generated_secret_here
 
-# Base URL of your Nextcloud instance — no trailing slash
+# Base URL of your Nextcloud instance — no trailing slash.
+# The collab server calls back to this URL for file I/O.
 NC_URL=https://nextcloud.example.com
-
-# Bot account credentials from Step 2
-NC_USER=tldraw-bot
-NC_PASS=your-app-password-here
 
 # Domain where this collab server will be reachable
 TLDRAW_HOST=tldraw.example.com
@@ -71,7 +58,7 @@ ACME_EMAIL=admin@example.com
 
 ---
 
-## Step 4: Configure Traefik
+## Step 3: Configure Traefik
 
 The `docker-compose.yml` ships with Traefik v3 labels on the `tldraw-sync` service and an optional Traefik service for new deployments.
 
@@ -92,7 +79,7 @@ Keep the `traefik` service in the compose file and ensure ports 80 and 443 are o
 
 ---
 
-## Step 5: Start the Service
+## Step 4: Start the Service
 
 The `docker-compose.yml` is pre-configured to pull the image from the **GitHub Container Registry**:
 
@@ -132,7 +119,7 @@ docker compose up -d
 
 ---
 
-## Step 6: Verify the Service
+## Step 5: Verify the Service
 
 ```bash
 # Check the container started cleanly
@@ -146,7 +133,7 @@ curl https://tldraw.example.com/health
 
 ---
 
-## Step 7: Configure Nextcloud
+## Step 6: Configure Nextcloud
 
 1. Log in to Nextcloud as an admin.
 2. Go to **Administration Settings > tldraw**.

--- a/lib/Controller/FileController.php
+++ b/lib/Controller/FileController.php
@@ -1,0 +1,298 @@
+<?php
+declare(strict_types=1);
+
+namespace OCA\Tldraw\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\StreamResponse;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\IConfig;
+use OCP\IRequest;
+
+/**
+ * Server-to-server file I/O callback endpoints.
+ *
+ * These endpoints are called by the collab server (not the browser) to read
+ * and write .tldr files and uploaded image assets on behalf of users.
+ *
+ * Authentication is via a storage token (HS256 JWT) issued alongside the
+ * WebSocket token by TldrawController::token(). No Nextcloud user session
+ * is required — the collab server never holds Nextcloud credentials.
+ *
+ * This follows the same pattern as Nextcloud's WOPI integration for Collabora
+ * and ONLYOFFICE: the external server calls back to PHP with a file-scoped
+ * token and PHP performs the I/O using IRootFolder.
+ */
+class FileController extends Controller {
+    private const ASSET_DIR = '.tldraw-assets';
+
+    private IRootFolder $rootFolder;
+    private IConfig $config;
+
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        IRootFolder $rootFolder,
+        IConfig $config
+    ) {
+        parent::__construct($appName, $request);
+        $this->rootFolder = $rootFolder;
+        $this->config = $config;
+    }
+
+    /**
+     * Read the raw content of a .tldr file.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     * @PublicPage
+     */
+    public function read(int $fileId): Http\Response {
+        $payload = $this->requireStorageToken(read: true);
+        if ($payload instanceof JSONResponse) return $payload;
+
+        if ((int)$payload['fileId'] !== $fileId) {
+            return new JSONResponse(['error' => 'Token/file mismatch'], 403);
+        }
+
+        try {
+            $file = $this->getFileNode((string)$payload['ownerId'], (string)$payload['filePath']);
+            $content = $file->getContent();
+            $response = new Http\DataDisplayResponse($content, 200, [
+                'Content-Type' => 'application/json',
+            ]);
+            return $response;
+        } catch (NotFoundException $e) {
+            // New file — return empty content so the collab server starts a blank room
+            return new Http\DataDisplayResponse('', 200, ['Content-Type' => 'application/json']);
+        } catch (\Exception $e) {
+            return new JSONResponse(['error' => 'Read failed'], 500);
+        }
+    }
+
+    /**
+     * Overwrite the content of a .tldr file.
+     * Requires canWrite: true in the storage token.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     * @PublicPage
+     */
+    public function save(int $fileId): JSONResponse {
+        $payload = $this->requireStorageToken(read: false);
+        if ($payload instanceof JSONResponse) return $payload;
+
+        if ((int)$payload['fileId'] !== $fileId) {
+            return new JSONResponse(['error' => 'Token/file mismatch'], 403);
+        }
+
+        $body = $this->request->getContent();
+        if (empty($body)) {
+            return new JSONResponse(['error' => 'Empty body'], 400);
+        }
+
+        try {
+            $ownerFolder = $this->rootFolder->getUserFolder((string)$payload['ownerId']);
+            try {
+                $file = $ownerFolder->get((string)$payload['filePath']);
+                $file->putContent($body);
+            } catch (NotFoundException $e) {
+                // File doesn't exist yet — create it
+                $ownerFolder->newFile((string)$payload['filePath'], $body);
+            }
+            return new JSONResponse(['status' => 'ok']);
+        } catch (NotPermittedException $e) {
+            return new JSONResponse(['error' => 'Not permitted'], 403);
+        } catch (\Exception $e) {
+            return new JSONResponse(['error' => 'Save failed'], 500);
+        }
+    }
+
+    /**
+     * Upload an image asset. Returns {assetKey} used to retrieve it later.
+     * Requires canWrite: true in the storage token.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     * @PublicPage
+     */
+    public function uploadAsset(int $fileId): JSONResponse {
+        $payload = $this->requireStorageToken(read: false);
+        if ($payload instanceof JSONResponse) return $payload;
+
+        if ((int)$payload['fileId'] !== $fileId) {
+            return new JSONResponse(['error' => 'Token/file mismatch'], 403);
+        }
+
+        // Collab server sends the file as raw body with Content-Type header
+        $mimeType = $this->request->getHeader('Content-Type') ?: 'application/octet-stream';
+        $data = $this->request->getContent();
+
+        if (empty($data)) {
+            return new JSONResponse(['error' => 'No data'], 400);
+        }
+
+        $allowedMimes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+        // Strip parameters from MIME (e.g. "image/png; charset=binary")
+        $baseMime = explode(';', $mimeType)[0];
+        $baseMime = trim($baseMime);
+        if (!in_array($baseMime, $allowedMimes, true)) {
+            return new JSONResponse(['error' => 'Unsupported file type'], 400);
+        }
+
+        $ext = match($baseMime) {
+            'image/jpeg' => 'jpg',
+            'image/png'  => 'png',
+            'image/gif'  => 'gif',
+            'image/webp' => 'webp',
+            default      => 'bin',
+        };
+
+        $ownerId = (string)$payload['ownerId'];
+        $filename = bin2hex(random_bytes(16)) . '.' . $ext;
+        $assetKey = $ownerId . '/' . $filename;
+
+        try {
+            $ownerFolder = $this->rootFolder->getUserFolder($ownerId);
+            if (!$ownerFolder->nodeExists(self::ASSET_DIR)) {
+                $ownerFolder->newFolder(self::ASSET_DIR);
+            }
+            $assetFolder = $ownerFolder->get(self::ASSET_DIR);
+            $assetFolder->newFile($filename, $data);
+
+            return new JSONResponse([
+                'assetKey' => base64_encode($assetKey),
+            ]);
+        } catch (\Exception $e) {
+            return new JSONResponse(['error' => 'Upload failed'], 500);
+        }
+    }
+
+    /**
+     * Serve an image asset. The assetKey is base64(ownerId/filename).
+     * Requires a valid storage token (read-only sufficient).
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     * @PublicPage
+     */
+    public function serveAsset(string $assetKey): Http\Response {
+        $payload = $this->requireStorageToken(read: true);
+        if ($payload instanceof JSONResponse) return $payload;
+
+        $decoded = base64_decode($assetKey, strict: true);
+        if ($decoded === false || !str_contains($decoded, '/')) {
+            return new JSONResponse(['error' => 'Invalid asset key'], 400);
+        }
+
+        [$ownerId, $filename] = explode('/', $decoded, 2);
+
+        // Path traversal guard
+        if (str_contains($filename, '/') || str_contains($filename, '..') ||
+            str_contains($ownerId, '/') || str_contains($ownerId, '..')) {
+            return new JSONResponse(['error' => 'Invalid path'], 400);
+        }
+
+        try {
+            $ownerFolder = $this->rootFolder->getUserFolder($ownerId);
+            $file = $ownerFolder->get(self::ASSET_DIR . '/' . $filename);
+            $content = $file->getContent();
+
+            $mime = match(true) {
+                str_ends_with($filename, '.png')            => 'image/png',
+                str_ends_with($filename, '.jpg')            => 'image/jpeg',
+                str_ends_with($filename, '.gif')            => 'image/gif',
+                str_ends_with($filename, '.webp')           => 'image/webp',
+                default                                      => 'application/octet-stream',
+            };
+
+            return new Http\DataDisplayResponse($content, 200, ['Content-Type' => $mime]);
+        } catch (NotFoundException $e) {
+            return new JSONResponse(['error' => 'Not found'], 404);
+        } catch (\Exception $e) {
+            return new JSONResponse(['error' => 'Serve failed'], 500);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Extract and validate the storage token from the Authorization: Bearer header.
+     * Returns the decoded payload array on success, or a JSONResponse on failure.
+     *
+     * @param bool $read  true = read access sufficient; false = canWrite required
+     * @return array|JSONResponse
+     */
+    private function requireStorageToken(bool $read): array|JSONResponse {
+        $authHeader = $this->request->getHeader('Authorization');
+        if (!$authHeader || !str_starts_with($authHeader, 'Bearer ')) {
+            return new JSONResponse(['error' => 'Missing token'], 401);
+        }
+
+        $token = substr($authHeader, 7);
+        $payload = $this->verifyStorageToken($token);
+        if ($payload === null) {
+            return new JSONResponse(['error' => 'Invalid or expired token'], 403);
+        }
+
+        if (($payload['type'] ?? '') !== 'storage') {
+            return new JSONResponse(['error' => 'Wrong token type'], 403);
+        }
+
+        if (!$read && empty($payload['canWrite'])) {
+            return new JSONResponse(['error' => 'Read-only token'], 403);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Verify an HS256 storage token. Returns decoded payload or null if invalid.
+     */
+    private function verifyStorageToken(string $token): ?array {
+        $secret = $this->config->getAppValue('tldraw', 'jwt_secret', '');
+        if (empty($secret)) return null;
+
+        $parts = explode('.', $token);
+        if (count($parts) !== 3) return null;
+
+        [$headerB64, $payloadB64, $signatureB64] = $parts;
+
+        $expected = rtrim(strtr(base64_encode(hash_hmac(
+            'sha256',
+            $headerB64 . '.' . $payloadB64,
+            $secret,
+            true
+        )), '+/', '-_'), '=');
+
+        if (!hash_equals($expected, $signatureB64)) return null;
+
+        $payload = json_decode(base64_decode(strtr($payloadB64, '-_', '+/')), true);
+        if (!is_array($payload)) return null;
+
+        if (isset($payload['exp']) && time() > $payload['exp']) return null;
+
+        return $payload;
+    }
+
+    /**
+     * Get a file node by owner ID and relative path.
+     *
+     * @throws NotFoundException
+     */
+    private function getFileNode(string $ownerId, string $filePath): \OCP\Files\File {
+        $ownerFolder = $this->rootFolder->getUserFolder($ownerId);
+        $node = $ownerFolder->get($filePath);
+        if (!($node instanceof \OCP\Files\File)) {
+            throw new NotFoundException("Not a file: $filePath");
+        }
+        return $node;
+    }
+}


### PR DESCRIPTION
## Summary

- **Eliminates the admin service account** (Issue #1). The Collab Server no longer holds any Nextcloud credentials.
- Implements a WOPI-style PHP callback API: four endpoints (`GET`/`PUT /file/{fileId}`, `POST /file/{fileId}/asset`, `GET /asset/{key}`) authenticated by file-scoped storage tokens.
- Storage tokens are 8-hour HS256 JWTs (same secret, `type: "storage"` discriminator) embedded inside the 60-second WebSocket JWT.
- The `webdav` npm package is removed; file I/O uses Node.js native `fetch`.
- `NC_USER` and `NC_PASS` are removed from `.env.example` and `docker-compose.yml`.
- Documentation updated throughout to reflect the new architecture.

## Security improvement

| Threat | Before | After |
|---|---|---|
| Compromised container | Admin WebDAV access to all user files, indefinitely | Only currently-open files, tokens expire in 8h |
| Stolen `.env` | Admin credentials | Only `JWT_SECRET_KEY` — still requires Nextcloud to be online |
| Revocation | Rotate NC_PASS + restart | Change JWT secret in Admin Settings — instant invalidation |
| Scope | Any file on the instance | Single file per token |

## Test plan

- [ ] `cd collab-server && npm install && npm run build` — compiles cleanly with `webdav` removed
- [ ] Open a `.tldr` file — editor loads and WebSocket room connects
- [ ] Inspect `/apps/tldraw/token/{fileId}` response — must contain both `token` (60s) and `storageToken` embedded in payload
- [ ] Make edits — auto-save PUTs to `/apps/tldraw/file/{fileId}` after 30 seconds
- [ ] Upload an image — POST to `/apps/tldraw/file/{fileId}/asset`, image renders in editor
- [ ] Verify `NC_USER`/`NC_PASS` absent from `docker-compose.yml` and `.env.example`
- [ ] Request with expired storage token returns 401

Closes #1
Closes #7