### PR TITLE
fix: straighten ASCII diagram in ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,14 +7,14 @@ This document describes the design of the Nextcloud tldraw application for contr
 The system connects Nextcloud (PHP) with a real-time Node.js WebSocket service. Nextcloud handles authentication and file storage; the Collab Server handles real-time sync. The two communicate via short-lived JWTs (WebSocket auth) and file-scoped storage tokens (file I/O callbacks). The Collab Server holds no Nextcloud credentials.
 
 ```
-┌─────────────────────────────────┐         ┌──────────────────────────────┐
-│         Nextcloud (PHP)         │         │    Collab Server (Node.js)   │
-│                                 │  60s JWT │                              │
-│  • User auth & file permissions │─────────►│  • WebSocket rooms           │
-│  • Issues JWTs + storage tokens │         │  • Real-time sync            │
-│  • Exposes file I/O callbacks   │◄─────────│  • Calls back for file I/O   │
-│  • Stores .tldr files & assets  │callbacks │  • No Nextcloud credentials  │
-└─────────────────────────────────┘         └──────────────────────────────┘
+┌─────────────────────────────────┐              ┌──────────────────────────────┐
+│         Nextcloud (PHP)         │              │    Collab Server (Node.js)   │
+│                                 │              │                              │
+│  • User auth & file permissions │── 60s JWT ──►│  • WebSocket rooms           │
+│  • Issues JWTs + storage tokens │              │  • Real-time sync            │
+│  • Exposes file I/O callbacks   │◄─ callbacks ─│  • Calls back for file I/O   │
+│  • Stores .tldr files & assets  │              │  • No Nextcloud credentials  │
+└─────────────────────────────────┘              └──────────────────────────────┘
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Fix inconsistent gap width in the architecture ASCII diagram (blank lines were 9 chars, arrow/label lines were 10 chars, causing the right box wall to shift by 1 on alternating lines).
- Move both labels inline with their arrows so placement is symmetric.

## Test plan

- [ ] Render the markdown and confirm the diagram is straight.

> **Note:** This branch is based on `feat/wopi-style-callback-api` and should be merged after PR #8.