### PR TITLE
feat: add Kubernetes manifests for collab server

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,165 @@
+# Kubernetes Deployment Guide
+
+This directory contains Kubernetes manifests for deploying the tldraw collab server.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `secret.yaml.example` | Secret template — copy, fill in, and apply (never commit the filled version) |
+| `deployment.yaml` | Main workload |
+| `service.yaml` | ClusterIP service exposing port 3000 |
+| `ingress-nginx.yaml` | Ingress for nginx-ingress-controller with WebSocket support |
+| `ingress-traefik.yaml` | IngressRoute for Traefik v2/v3 (CRD-based) with WebSocket support |
+
+---
+
+## Prerequisites
+
+- Kubernetes 1.24+
+- One of:
+  - **nginx-ingress-controller** → use `ingress-nginx.yaml`
+  - **Traefik v2/v3** as a Kubernetes controller with CRDs installed → use `ingress-traefik.yaml`
+- **cert-manager** (recommended for TLS) or manually-managed TLS Secrets
+- Image pull access to `ghcr.io/larkly/nextcloud-tldraw:latest` (public, no credentials required)
+
+---
+
+## Single-Replica Constraint
+
+> **Do not increase `replicas` beyond 1 without adding shared state.**
+
+Room state is stored in an in-memory `Map` inside the collab server process
+(`collab-server/src/room-manager.ts`). With more than one replica and no sticky
+sessions, a user on pod A and a user on pod B editing the same file would each
+see only their own changes — edits diverge silently.
+
+**Upgrade path to multiple replicas:**
+
+1. Replace the in-memory room map with a shared store (e.g. Redis Pub/Sub or a
+   shared SQLite file on a `ReadWriteMany` PVC).
+2. Or enable session affinity on the ingress so all WebSocket connections for a
+   given room always land on the same pod:
+   - nginx: `nginx.ingress.kubernetes.io/affinity: "cookie"`
+   - Traefik: use a `StickySession` service configuration
+
+The `deployment.yaml` includes a `podAntiAffinity` rule that prevents the
+scheduler from placing two `tldraw-sync` pods on the same node, making an
+accidental scale-up visible as a scheduling failure rather than a silent data
+split.
+
+---
+
+## Quick Start
+
+### 1. Create the namespace
+
+```bash
+kubectl create namespace tldraw
+```
+
+### 2. Create the Secret
+
+```bash
+cp k8s/secret.yaml.example k8s/secret.yaml
+# Edit secret.yaml — replace the placeholder base64 values with real ones:
+#   echo -n 'your-value' | base64
+vim k8s/secret.yaml
+kubectl apply -f k8s/secret.yaml
+```
+
+### 3. Apply the remaining manifests
+
+Choose the ingress file that matches your controller:
+
+```bash
+# nginx-ingress
+kubectl apply -f k8s/deployment.yaml -f k8s/service.yaml -f k8s/ingress-nginx.yaml
+
+# Traefik (CRD-based)
+kubectl apply -f k8s/deployment.yaml -f k8s/service.yaml -f k8s/ingress-traefik.yaml
+```
+
+Or apply the whole directory (edit or delete the ingress file you don't need first):
+
+```bash
+kubectl apply -f k8s/
+```
+
+### 4. Verify
+
+```bash
+kubectl -n tldraw get pods
+kubectl -n tldraw logs deployment/tldraw-sync
+# Should print: Collab Server running on port 3000
+
+# Health check through the service
+kubectl -n tldraw port-forward svc/tldraw-sync 3000:3000 &
+curl http://localhost:3000/health
+# {"status":"ok"}
+```
+
+---
+
+## Dry-Run Validation
+
+```bash
+kubectl apply --dry-run=client -f k8s/deployment.yaml -f k8s/service.yaml -f k8s/ingress-nginx.yaml
+```
+
+---
+
+## Migrating from Docker Compose
+
+The environment variables are identical. Map your `.env` values directly to the
+Secret:
+
+| `.env` key | Secret key |
+|---|---|
+| `JWT_SECRET_KEY` | `JWT_SECRET_KEY` |
+| `NC_URL` | `NC_URL` |
+| `NC_USER` | `NC_USER` |
+| `NC_PASS` | `NC_PASS` |
+
+`TLDRAW_HOST` and `ACME_EMAIL` are not needed — hostname and TLS are handled by
+the Ingress / cert-manager instead.
+
+After switching, update the **Collab Server URL** in Nextcloud's Administration
+Settings to point to your new ingress hostname (e.g. `https://tldraw.example.com`).
+
+---
+
+## TLS Options
+
+### cert-manager (recommended)
+
+Install cert-manager and create a `ClusterIssuer`, then the manifests will
+automatically provision certificates. The `ingress-nginx.yaml` annotation
+`cert-manager.io/cluster-issuer: letsencrypt-prod` triggers this.
+
+For Traefik, create a `Certificate` resource in the `tldraw` namespace:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tldraw-tls
+  namespace: tldraw
+spec:
+  secretName: tldraw-tls
+  dnsNames:
+    - tldraw.example.com
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+```
+
+### Manual TLS
+
+Create a TLS Secret directly and reference it in the ingress:
+
+```bash
+kubectl -n tldraw create secret tls tldraw-tls \
+  --cert=path/to/tls.crt \
+  --key=path/to/tls.key
+```

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tldraw-sync
+  namespace: tldraw
+  labels:
+    app: tldraw-sync
+spec:
+  # WARNING: Keep replicas at 1.
+  # Room state is held in-memory per process. Running more than one replica
+  # without sticky sessions will split room state across pods and cause edits
+  # from different users to diverge silently.
+  # See k8s/README.md for details and the upgrade path.
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tldraw-sync
+  template:
+    metadata:
+      labels:
+        app: tldraw-sync
+    spec:
+      # Prevent the scheduler from placing a second pod on any node if replicas
+      # is accidentally increased — makes the single-replica constraint visible.
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: tldraw-sync
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: tldraw-sync
+          image: ghcr.io/larkly/nextcloud-tldraw:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          env:
+            - name: PORT
+              value: "3000"
+            # NODE_OPTIONS is already set in the Dockerfile; override here is
+            # intentional to make the requirement explicit in the manifest.
+            - name: NODE_OPTIONS
+              value: "--experimental-sqlite"
+            - name: JWT_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: tldraw-secret
+                  key: JWT_SECRET_KEY
+            - name: NC_URL
+              valueFrom:
+                secretKeyRef:
+                  name: tldraw-secret
+                  key: NC_URL
+            - name: NC_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tldraw-secret
+                  key: NC_USER
+            - name: NC_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tldraw-secret
+                  key: NC_PASS
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "1000m"
+      restartPolicy: Always

--- a/k8s/ingress-nginx.yaml
+++ b/k8s/ingress-nginx.yaml
@@ -1,0 +1,37 @@
+# Nginx Ingress Controller — WebSocket-capable ingress for the collab server.
+# Replace tldraw.example.com with your actual hostname.
+# Assumes cert-manager is installed and a ClusterIssuer named "letsencrypt-prod" exists.
+# Remove the cert-manager annotations and tls block if you manage TLS another way.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tldraw-sync
+  namespace: tldraw
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    # TLS — cert-manager (remove if managing TLS manually)
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    # WebSocket support: keep the connection open for up to 1 hour
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    # Force HTTP/1.1 so nginx can forward the Upgrade header
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+spec:
+  tls:
+    - hosts:
+        - tldraw.example.com
+      secretName: tldraw-tls
+  rules:
+    - host: tldraw.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tldraw-sync
+                port:
+                  number: 3000

--- a/k8s/ingress-traefik.yaml
+++ b/k8s/ingress-traefik.yaml
@@ -1,0 +1,44 @@
+# Traefik IngressRoute — for Traefik v2/v3 deployed as a Kubernetes controller
+# (i.e. using the Traefik CRDs, not the Docker label approach).
+# Replace tldraw.example.com with your actual hostname.
+#
+# This assumes:
+#   - Traefik is installed with its CRDs (traefik.io/v1alpha1)
+#   - A TLS certificate is available via cert-manager or a manually-managed Secret
+#   - The "websecure" entrypoint is configured on port 443
+---
+# Middleware: pass Upgrade/Connection headers so WebSocket handshakes work
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: tldraw-websocket-headers
+  namespace: tldraw
+spec:
+  headers:
+    customRequestHeaders:
+      Upgrade: "websocket"
+      Connection: "Upgrade"
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: tldraw-sync
+  namespace: tldraw
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`tldraw.example.com`)
+      kind: Rule
+      middlewares:
+        - name: tldraw-websocket-headers
+      services:
+        - name: tldraw-sync
+          port: 3000
+  tls:
+    # Option A: cert-manager certificate (recommended)
+    # Create a Certificate resource in the tldraw namespace that writes to
+    # "tldraw-tls", then reference it here.
+    secretName: tldraw-tls
+    # Option B: Traefik-managed ACME (remove secretName, add certResolver)
+    # certResolver: myresolver

--- a/k8s/secret.yaml.example
+++ b/k8s/secret.yaml.example
@@ -1,0 +1,19 @@
+# Example Secret — copy to secret.yaml, fill in real values, then apply.
+# Do NOT commit secret.yaml to version control.
+#
+# Base64-encode each value:  echo -n 'your-value' | base64
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tldraw-secret
+  namespace: tldraw
+type: Opaque
+data:
+  # echo -n 'change_me_to_random_hex_32_bytes' | base64
+  JWT_SECRET_KEY: Y2hhbmdlX21lX3RvX3JhbmRvbV9oZXhfMzJfYnl0ZXM=
+  # echo -n 'https://nextcloud.example.com' | base64
+  NC_URL: aHR0cHM6Ly9uZXh0Y2xvdWQuZXhhbXBsZS5jb20=
+  # echo -n 'tldraw-bot' | base64
+  NC_USER: dGxkcmF3LWJvdA==
+  # echo -n 'your-secure-app-password' | base64
+  NC_PASS: eW91ci1zZWN1cmUtYXBwLXBhc3N3b3Jk

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tldraw-sync
+  namespace: tldraw
+spec:
+  selector:
+    app: tldraw-sync
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+  type: ClusterIP


### PR DESCRIPTION
## Summary

- Adds a `k8s/` directory with production-ready manifests for deploying the collab server on Kubernetes
- Covers both nginx-ingress-controller and Traefik v2/v3 (CRD-based) ingress options
- Documents the single-replica constraint (in-memory room state) with a `podAntiAffinity` guard and upgrade path

## Files added

| File | Purpose |
|---|---|
| `k8s/deployment.yaml` | Workload — `replicas: 1`, probes on `/health`, 512Mi/1CPU limits |
| `k8s/service.yaml` | ClusterIP service on port 3000 |
| `k8s/ingress-nginx.yaml` | Nginx Ingress with WebSocket headers and cert-manager TLS |
| `k8s/ingress-traefik.yaml` | Traefik `Middleware` + `IngressRoute` CRD with WebSocket support |
| `k8s/secret.yaml.example` | Secret template (placeholder values only — not committed with real secrets) |
| `k8s/README.md` | Prerequisites, quick-start, single-replica constraint, Docker Compose migration guide |

## Test plan

- [ ] `kubectl apply --dry-run=client -f k8s/deployment.yaml -f k8s/service.yaml -f k8s/ingress-nginx.yaml` passes
- [ ] Pod reaches `Running`; liveness and readiness probes pass (`/health` → `{"status":"ok"}`)
- [ ] WebSocket connection established from Nextcloud frontend through ingress
- [ ] Collaborative editing works across two browser tabs
