### PR TITLE
fix: per-IP WebSocket connection rate limiting

### DIFF
--- a/collab-server/src/server.ts
+++ b/collab-server/src/server.ts
@@ -19,7 +19,10 @@ const MAX_WS_CONNECTIONS_PER_IP = 10;
 function getClientIp(req: IncomingMessage): string {
 	const forwarded = req.headers['x-forwarded-for'];
 	if (forwarded) {
-		return (Array.isArray(forwarded) ? forwarded[0] : forwarded).split(',')[0].trim();
+		// Use the rightmost entry: Traefik appends the real client IP to the end of the
+		// chain. The leftmost entries are client-supplied and trivially spoofable.
+		const chain = Array.isArray(forwarded) ? forwarded[0] : forwarded;
+		return chain.split(',').at(-1)!.trim();
 	}
 	return req.socket.remoteAddress ?? 'unknown';
 }


### PR DESCRIPTION
## Summary

- `express-rate-limit` only covers Express middleware; `server.on('upgrade', ...)` events bypass it entirely, leaving WebSocket connections unthrottled
- Adds a lightweight in-process `Map<ip, count>` counter in the upgrade handler
- Rejects connections over 10 per IP with `HTTP 429` before any JWT work is done
- Counter is decremented via `ws.once('close')` and the key is deleted at zero to prevent unbounded map growth
- `getClientIp()` reads `X-Forwarded-For` (set by Traefik) with fallback to `req.socket.remoteAddress`

Closes #11

## Test plan

- [ ] Build passes: `cd collab-server && npm run build`
- [ ] Opening ≤ 10 WebSocket connections from the same IP succeeds
- [ ] Opening an 11th connection from the same IP receives `HTTP 429` and is closed
- [ ] Closing a connection decrements the counter so a new connection is accepted