### PR TITLE
docs: add project archived notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 > [!CAUTION]
 > **Project is archived.** As tldraw is proprietary and requires a license to use in production, it has some unacceptable implications for any Nextcloud instance in production to utilize this. As such, the work has been ended and the repository archived.
 
-> [!WARNING]
-> **This project is currently in early development and is not ready for production use.**
-> We are actively working on it, and pull requests are accepted and greatly appreciated!
-
 ```
   _   _           _       _                 _
  | \ | | _____  _| |_ ___| | ___  _   _  __| |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nextcloud tldraw App
 
-> [!CRITICAL]
-> ** Project is archived. As tldraw is proprietary and requires a license to use in production, it has some unacceptable implications for any Nextcloud instance in production to utilize this. As such, the work has been ended and the repository archived. 
+> [!CAUTION]
+> **Project is archived.** As tldraw is proprietary and requires a license to use in production, it has some unacceptable implications for any Nextcloud instance in production to utilize this. As such, the work has been ended and the repository archived.
 
 > [!WARNING]
 > **This project is currently in early development and is not ready for production use.**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Nextcloud tldraw App
 
+> [!CRITICAL]
+> ** Project is archived. As tldraw is proprietary and requires a license to use in production, it has some unacceptable implications for any Nextcloud instance in production to utilize this. As such, the work has been ended and the repository archived. 
+
 > [!WARNING]
 > **This project is currently in early development and is not ready for production use.**
 > We are actively working on it, and pull requests are accepted and greatly appreciated!


### PR DESCRIPTION
## Summary

- Adds a `[!CRITICAL]` callout at the top of the README noting that the project is archived due to tldraw's proprietary licence requirements making production use untenable.

## Test plan

- [ ] Verify the callout renders correctly on GitHub
